### PR TITLE
Fix ambiguity with setting up reading mode

### DIFF
--- a/Example/SoundWave/AudioPlayerManager.swift
+++ b/Example/SoundWave/AudioPlayerManager.swift
@@ -36,7 +36,7 @@ final class AudioPlayerManager: NSObject {
 			throw AudioErrorType.alreadyPlaying
 		}
 
-		if !URL.checkPath(url.absoluteString) {
+		if !URL.checkPath(url.path) {
 			print("Audio Player did fail to start: file doesn't exist")
 			throw AudioErrorType.audioFileWrongPath
 		}

--- a/Example/SoundWave/SoundWave+Helpers.swift
+++ b/Example/SoundWave/SoundWave+Helpers.swift
@@ -35,7 +35,10 @@ extension UIViewController {
 		alertController.addAction(UIAlertAction(title: "OK", style: .cancel) { _ in
 			alertController.dismiss(animated: true, completion: nil)
 		})
-		self.present(alertController, animated: true, completion: nil)
+        
+        DispatchQueue.main.async {
+            self.present(alertController, animated: true, completion: nil)
+        }
 	}
 }
 

--- a/Example/SoundWave/SoundWave+Helpers.swift
+++ b/Example/SoundWave/SoundWave+Helpers.swift
@@ -9,13 +9,10 @@
 import UIKit
 
 extension URL {
-	static func checkPath(_ path: String) -> Bool {
-		var directory: ObjCBool = ObjCBool(false)
-		if FileManager.default.fileExists(atPath: path, isDirectory:&directory) {
-			return !directory.boolValue
-		}
-		return false
-	}
+    static func checkPath(_ path: String) -> Bool {
+        let isFileExist = FileManager.default.fileExists(atPath: path)
+        return isFileExist
+    }
 	
 	static func documentsPath(forFileName fileName: String) -> URL? {
 		let documents = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true)[0]

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If there are **not enough** / **too many** values to fit the screen, those value
 
 ```swift
 self.audioVisualizationView.audioVisualizationMode = .read
-self.audioVisualizationView.meteringLevelsArray = [0.1, 0.67, 0.13, 0.78, 0.31]
+self.audioVisualizationView.meteringLevels = [0.1, 0.67, 0.13, 0.78, 0.31]
 self.play(for: 5.0)
 ```
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ If there are **not enough** / **too many** values to fit the screen, those value
 ```swift
 self.audioVisualizationView.audioVisualizationMode = .read
 self.audioVisualizationView.meteringLevels = [0.1, 0.67, 0.13, 0.78, 0.31]
-self.play(for: 5.0)
+self.audioVisualizationView.play(for: 5.0)
 ```
 
 Specify the duration of your sound for the view to play exactly at the same pace (and your metering levels fit the sound power heard by the user).

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -38,7 +38,7 @@ public class AudioVisualizationView: BaseNibView {
 	// Do not specify any `gradientPercentage` for gradient calculating fitting size automatically.
 	public var currentGradientPercentage: Float?
 
-	public var meteringLevelsArray: [Float] = []	// Mutating recording array (values are percentage: 0.0 to 1.0)
+	private var meteringLevelsArray: [Float] = []	// Mutating recording array (values are percentage: 0.0 to 1.0)
 	private var meteringLevelsClusteredArray: [Float] = [] // Generated read mode array (values are percentage: 0.0 to 1.0)
 
 	private var currentMeteringLevelsArray: [Float] {


### PR DESCRIPTION
The doc is wrong, when I tried to change meteringLevelsArray causes
crash during runtime. meteringLevels Should be set instead. Making it
private should prevent this issue.

Also other fixes.