### PR TITLE
Add play from functionality and ability to manipulate the AudioVizualizerView with touches via move() method

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/Example/Pods/Pods.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/Example/SoundWave/AudioPlayerManager.swift
+++ b/Example/SoundWave/AudioPlayerManager.swift
@@ -25,7 +25,7 @@ final class AudioPlayerManager: NSObject {
 
 	// MARK: - Reinit and play from the beginning
 
-	func play(at url: URL, with audioVisualizationTimeInterval: TimeInterval = 0.05) throws -> TimeInterval {
+	func play(at url: URL, atTimePercentage: Float, with audioVisualizationTimeInterval: TimeInterval = 0.05) throws -> TimeInterval {
 		if AudioRecorderManager.shared.isRunning {
 			print("Audio Player did fail to start: AVFoundation is recording")
 			throw AudioErrorType.alreadyRecording
@@ -42,22 +42,27 @@ final class AudioPlayerManager: NSObject {
 		}
 
 		try self.audioPlayer = AVAudioPlayer(contentsOf: url)
-		self.setupPlayer(with: audioVisualizationTimeInterval)
+    let duration = self.audioPlayer!.duration
+    let normalizedFromValue = Float(duration) * atTimePercentage
+    self.setupPlayer(atTime: TimeInterval(normalizedFromValue), with: audioVisualizationTimeInterval)
 		print("Started to play sound")
 
-		return self.audioPlayer!.duration
+		return duration
 	}
 
-	func play(_ data: Data, with audioVisualizationTimeInterval: TimeInterval = 0.05) throws -> TimeInterval {
+  func play(_ data: Data, atTimePercentage: Float, with audioVisualizationTimeInterval: TimeInterval = 0.05) throws -> TimeInterval {
 		try self.audioPlayer = AVAudioPlayer(data: data)
-		self.setupPlayer(with: audioVisualizationTimeInterval)
+    let duration = self.audioPlayer!.duration
+    let normalizedFromValue = Float(duration) * atTimePercentage
+    self.setupPlayer(atTime: TimeInterval(normalizedFromValue), with: audioVisualizationTimeInterval)
 		print("Started to play sound")
 
-		return self.audioPlayer!.duration
+		return duration
 	}
 	
-	private func setupPlayer(with audioVisualizationTimeInterval: TimeInterval) {
+  private func setupPlayer(atTime: TimeInterval, with audioVisualizationTimeInterval: TimeInterval) {
 		if let player = self.audioPlayer {
+      player.currentTime = atTime
 			player.play()
 			player.isMeteringEnabled = true
 			player.delegate = self

--- a/Example/SoundWave/Info.plist
+++ b/Example/SoundWave/Info.plist
@@ -22,6 +22,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>Allow the microphone usage.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>

--- a/Example/SoundWave/ViewController.swift
+++ b/Example/SoundWave/ViewController.swift
@@ -117,7 +117,7 @@ class ViewController: UIViewController {
 				let duration = try self.viewModel.startPlaying()
 				self.currentState = .playing
 				self.audioVisualizationView.meteringLevels = self.viewModel.currentAudioRecord!.meteringLevels
-				self.audioVisualizationView.play(for: duration)
+				self.audioVisualizationView.play(totalDuration: duration)
 			} catch {
 				self.showAlert(with: error)
 			}

--- a/Example/SoundWave/ViewController.swift
+++ b/Example/SoundWave/ViewController.swift
@@ -112,15 +112,24 @@ class ViewController: UIViewController {
 				self.currentState = .ready
 				self.showAlert(with: error)
 			}
-		case .recorded, .paused:
+		case .recorded:
 			do {
 				let duration = try self.viewModel.startPlaying()
 				self.currentState = .playing
 				self.audioVisualizationView.meteringLevels = self.viewModel.currentAudioRecord!.meteringLevels
-				self.audioVisualizationView.play(totalDuration: duration)
+                self.audioVisualizationView.play(totalDuration: duration)
 			} catch {
 				self.showAlert(with: error)
 			}
+        case .paused:
+            do {
+                _ = try self.viewModel.startPlaying()
+                self.currentState = .playing
+                self.audioVisualizationView.meteringLevels = self.viewModel.currentAudioRecord!.meteringLevels
+                self.audioVisualizationView.resume()
+            } catch {
+                self.showAlert(with: error)
+            }
 		case .playing:
 			do {
 				try self.viewModel.pausePlaying()

--- a/Example/SoundWave/ViewController.swift
+++ b/Example/SoundWave/ViewController.swift
@@ -59,11 +59,13 @@ class ViewController: UIViewController {
 	}
 	
 	private var chronometer: Chronometer?
-	
+  
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		
-		self.viewModel.askAudioRecordingPermission()
+    
+    self.audioVisualizationView.touchesDelegate = self
+
+    self.viewModel.askAudioRecordingPermission()
 		
 		self.viewModel.audioMeteringLevelUpdate = { [weak self] meteringLevel in
 			guard let this = self, this.audioVisualizationView.audioVisualizationMode == .write else {
@@ -192,4 +194,45 @@ class ViewController: UIViewController {
 			self.view.layoutIfNeeded()
 		}
 	}
+}
+
+extension ViewController: AudioVizualitzationViewTouchesDelegate {
+  
+    func touchesBegan(on view: AudioVisualizationView, _ touches: Set<UITouch>, with event: UIEvent?) {
+      handleTouches(touches)
+    }
+  
+    func touchesMoved(on view: AudioVisualizationView, _ touches: Set<UITouch>, with event: UIEvent?) {
+    }
+  
+    func touchesEnded(on view: AudioVisualizationView, _ touches: Set<UITouch>, with event: UIEvent?) {
+    }
+  
+    func touchesCancelled(on view: AudioVisualizationView, _ touches: Set<UITouch>, with event: UIEvent?) {
+    }
+  
+    private func handleTouches(_ touches: Set<UITouch>) {
+      guard let firstTouch = touches.randomElement() else {
+        return
+      }
+      
+      let currentPoint = firstTouch.location(in: self.audioVisualizationView)
+      switch self.currentState {
+      case .recorded:
+        do {
+          self.currentState = .playing
+          let duration = try self.viewModel.startPlaying(atTimePercentage: Float(currentPoint.x / self.audioVisualizationView.frame.width))
+          self.audioVisualizationView.meteringLevels = self.viewModel.currentAudioRecord!.meteringLevels
+          
+          let normalizedFromValue = CGFloat(duration) * (currentPoint.x / self.audioVisualizationView.frame.width)
+
+          self.audioVisualizationView.play(from: TimeInterval(normalizedFromValue), totalDuration: duration)
+        } catch {
+          self.showAlert(with: error)
+        }
+      default:
+        break
+      }
+    }
+  
 }

--- a/Example/SoundWave/ViewModel.swift
+++ b/Example/SoundWave/ViewModel.swift
@@ -67,7 +67,7 @@ final class ViewModel {
 	
 	// MARK: - Playing
 	
-	func startPlaying() throws -> TimeInterval {
+  func startPlaying(atTimePercentage: Float = 0) throws -> TimeInterval {
 		guard let currentAudioRecord = self.currentAudioRecord else {
 			throw AudioErrorType.audioFileWrongPath
 		}
@@ -80,7 +80,7 @@ final class ViewModel {
 			}
 			
 			self.isPlaying = true
-			return try AudioPlayerManager.shared.play(at: audioFilePath, with: self.audioVisualizationTimeInterval)
+      return try AudioPlayerManager.shared.play(at: audioFilePath, atTimePercentage: atTimePercentage, with: self.audioVisualizationTimeInterval)
 		}
 	}
 	

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -147,13 +147,7 @@ public class AudioVisualizationView: BaseNibView {
     // PRAGMA: - Play Mode Handling
 
     public func play(for duration: TimeInterval) {
-        guard self.audioVisualizationMode == .read else {
-            fatalError("trying to read audio visualization in write mode")
-        }
-
-        guard self.meteringLevels != nil else {
-            fatalError("trying to read audio visualization of non initialized sound record")
-        }
+      
 
         if let currentChronometer = self.playChronometer {
             currentChronometer.start() // resume current
@@ -178,37 +172,40 @@ public class AudioVisualizationView: BaseNibView {
         }
     }
 
-    public func play(from position: TimeInterval, fromTotalDuration duration: TimeInterval, shouldContinuePlaying: Bool) {
-
+    public func play(from position: TimeInterval = 0, fromTotalDuration duration: TimeInterval) {
+      
+        guard self.audioVisualizationMode == .read else {
+          fatalError("trying to read audio visualization in write mode")
+        }
+      
+        guard self.meteringLevels != nil else {
+          fatalError("trying to read audio visualization of non initialized sound record")
+        }
+        
         self.currentGradientPercentage = Float(position) / Float(duration)
         self.setNeedsDisplay()
 
-        if let isPlaying = playChronometer?.isPlaying {
-            if isPlaying { pause() }
-        }
-
-        self.playChronometer?.timerCurrentValue = position
         if let currentChronometer = self.playChronometer {
+            currentChronometer.timerCurrentValue = position
             currentChronometer.start() // resume current
             return
         }
 
         self.playChronometer = Chronometer(withTimeInterval: self.audioVisualizationTimeInterval)
+        self.playChronometer?.timerCurrentValue = position
         self.playChronometer?.start(shouldFire: false)
-        if shouldContinuePlaying {
-            self.playChronometer?.timerDidUpdate = { [weak self] timerDuration in
-                guard let this = self else {
-                    return
-                }
-
-                if position >= duration {
-                    this.stop()
-                    return
-                }
-
-                this.currentGradientPercentage = Float(position) / Float(duration)
-                this.setNeedsDisplay()
+        self.playChronometer?.timerDidUpdate = { [weak self] timerDuration in
+            guard let this = self else {
+                return
             }
+
+            if timerDuration >= duration {
+                this.stop()
+                return
+            }
+
+            this.currentGradientPercentage = Float(timerDuration) / Float(duration)
+            this.setNeedsDisplay()
         }
     }
 

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -175,13 +175,13 @@ public class AudioVisualizationView: BaseNibView {
     public func play(from position: TimeInterval = 0, fromTotalDuration duration: TimeInterval) {
       
         guard self.audioVisualizationMode == .read else {
-          fatalError("trying to read audio visualization in write mode")
+            fatalError("trying to read audio visualization in write mode")
         }
       
         guard self.meteringLevels != nil else {
-          fatalError("trying to read audio visualization of non initialized sound record")
+            fatalError("trying to read audio visualization of non initialized sound record")
         }
-        
+      
         self.currentGradientPercentage = Float(position) / Float(duration)
         self.setNeedsDisplay()
 
@@ -207,6 +207,26 @@ public class AudioVisualizationView: BaseNibView {
             this.currentGradientPercentage = Float(timerDuration) / Float(duration)
             this.setNeedsDisplay()
         }
+    }
+  
+    public func move(to position: TimeInterval, fromTotalDuration duration: TimeInterval) {
+      
+        guard let currentChronometer = self.playChronometer else {
+            return
+        }
+      
+        guard self.audioVisualizationMode == .read else {
+            fatalError("trying to read audio visualization in write mode")
+        }
+      
+        guard self.meteringLevels != nil else {
+            fatalError("trying to read audio visualization of non initialized sound record")
+        }
+      
+        currentChronometer.timerCurrentValue = position
+
+        self.currentGradientPercentage = Float(position) / Float(duration)
+        self.setNeedsDisplay()
     }
 
     public func pause() {

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -186,7 +186,7 @@ public class AudioVisualizationView: BaseNibView {
     public func move(to position: TimeInterval, fromTotalDuration duration: TimeInterval) {
       
         guard let currentChronometer = self.playChronometer else {
-            return
+            fatalError("trying to move audio vizualization when it has not been started")
         }
       
         guard self.audioVisualizationMode == .read else {
@@ -212,7 +212,7 @@ public class AudioVisualizationView: BaseNibView {
   
     public func resume() {
         guard let chronometer = self.playChronometer, !chronometer.isPlaying else {
-          return
+            fatalError("trying to resume audio visualization view when is already playing")
         }
         chronometer.start()
     }

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -198,9 +198,23 @@ public class AudioVisualizationView: BaseNibView {
         }
       
         currentChronometer.timerCurrentValue = position
-
+      
         self.currentGradientPercentage = Float(position) / Float(duration)
         self.setNeedsDisplay()
+      
+        currentChronometer.timerDidUpdate = { [weak self] timerDuration in
+            guard let this = self else {
+                return
+            }
+          
+            if timerDuration >= duration {
+                this.stop()
+                return
+            }
+          
+            this.currentGradientPercentage = Float(timerDuration) / Float(duration)
+            this.setNeedsDisplay()
+        }
     }
 
     public func pause() {

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -146,33 +146,7 @@ public class AudioVisualizationView: BaseNibView {
 
     // PRAGMA: - Play Mode Handling
 
-    public func play(for duration: TimeInterval) {
-      
-
-        if let currentChronometer = self.playChronometer {
-            currentChronometer.start() // resume current
-            return
-        }
-
-        self.playChronometer = Chronometer(withTimeInterval: self.audioVisualizationTimeInterval)
-        self.playChronometer?.start(shouldFire: false)
-
-        self.playChronometer?.timerDidUpdate = { [weak self] timerDuration in
-            guard let this = self else {
-                return
-            }
-
-            if timerDuration >= duration {
-                this.stop()
-                return
-            }
-
-            this.currentGradientPercentage = Float(timerDuration) / Float(duration)
-            this.setNeedsDisplay()
-        }
-    }
-
-    public func play(from position: TimeInterval = 0, fromTotalDuration duration: TimeInterval) {
+    public func play(from position: TimeInterval = 0, totalDuration duration: TimeInterval) {
       
         guard self.audioVisualizationMode == .read else {
             fatalError("trying to read audio visualization in write mode")

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -7,12 +7,24 @@
 
 import UIKit
 
+public protocol AudioVizualitzationViewTouchesDelegate: class {
+  
+    func touchesBegan(on view: AudioVisualizationView, _ touches: Set<UITouch>, with event: UIEvent?)
+  
+    func touchesMoved(on view: AudioVisualizationView, _ touches: Set<UITouch>, with event: UIEvent?)
+  
+    func touchesEnded(on view: AudioVisualizationView, _ touches: Set<UITouch>, with event: UIEvent?)
+  
+    func touchesCancelled(on view: AudioVisualizationView, _ touches: Set<UITouch>, with event: UIEvent?)
+
+}
+
 public class AudioVisualizationView: BaseNibView {
     public enum AudioVisualizationMode {
         case read
         case write
     }
-
+  
     @IBInspectable public var meteringLevelBarWidth: CGFloat = 3.0 {
         didSet {
             self.setNeedsDisplay()
@@ -28,6 +40,8 @@ public class AudioVisualizationView: BaseNibView {
             self.setNeedsDisplay()
         }
     }
+  
+    public weak var touchesDelegate: AudioVizualitzationViewTouchesDelegate?
 
     public var audioVisualizationMode: AudioVisualizationMode = .read
 
@@ -238,6 +252,24 @@ public class AudioVisualizationView: BaseNibView {
         self.currentGradientPercentage = 1.0
         self.setNeedsDisplay()
         self.currentGradientPercentage = nil
+    }
+  
+    // MARK : - Touches
+  
+    public override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.touchesDelegate?.touchesBegan(on: self, touches, with: event)
+    }
+  
+    public override func touchesMoved(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.touchesDelegate?.touchesMoved(on: self, touches, with: event)
+    }
+  
+    public override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.touchesDelegate?.touchesEnded(on: self, touches, with: event)
+    }
+  
+    public override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent?) {
+        self.touchesDelegate?.touchesCancelled(on: self, touches, with: event)
     }
 
     // MARK: - Mask + Gradient

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -209,6 +209,13 @@ public class AudioVisualizationView: BaseNibView {
         }
         self.playChronometer?.pause()
     }
+  
+    public func resume() {
+        guard let chronometer = self.playChronometer, !chronometer.isPlaying else {
+          return
+        }
+        chronometer.start()
+    }
 
     public func stop() {
         self.playChronometer?.stop()

--- a/SoundWave/Classes/AudioVisualizationView.swift
+++ b/SoundWave/Classes/AudioVisualizationView.swift
@@ -8,319 +8,356 @@
 import UIKit
 
 public class AudioVisualizationView: BaseNibView {
-	public enum AudioVisualizationMode {
-		case read
-		case write
-	}
-
-	@IBInspectable public var meteringLevelBarWidth: CGFloat = 3.0 {
-		didSet {
-			self.setNeedsDisplay()
-		}
-	}
-	@IBInspectable public var meteringLevelBarInterItem: CGFloat = 2.0 {
-		didSet {
-			self.setNeedsDisplay()
-		}
-	}
-	@IBInspectable public var meteringLevelBarCornerRadius: CGFloat = 2.0 {
-		didSet {
-			self.setNeedsDisplay()
-		}
-	}
-
-	public var audioVisualizationMode: AudioVisualizationMode = .read
-	
-	public var audioVisualizationTimeInterval: TimeInterval = 0.05 // Time interval between each metering bar representation
-
-	// Specify a `gradientPercentage` to have the width of gradient be that percentage of the view width (starting from left)
-	// The rest of the screen will be filled by `self.gradientStartColor` to display nicely.
-	// Do not specify any `gradientPercentage` for gradient calculating fitting size automatically.
-	public var currentGradientPercentage: Float?
-
-	private var meteringLevelsArray: [Float] = []	// Mutating recording array (values are percentage: 0.0 to 1.0)
-	private var meteringLevelsClusteredArray: [Float] = [] // Generated read mode array (values are percentage: 0.0 to 1.0)
-
-	private var currentMeteringLevelsArray: [Float] {
-		if !self.meteringLevelsClusteredArray.isEmpty {
-			return meteringLevelsClusteredArray
-		}
-		return meteringLevelsArray
-	}
-
-	private var playChronometer: Chronometer?
-
-	public var meteringLevels: [Float]? {
-		didSet {
-			if let meteringLevels = self.meteringLevels {
-				self.meteringLevelsClusteredArray = meteringLevels
-				self.currentGradientPercentage = 0.0
-				_ = self.scaleSoundDataToFitScreen()
-			}
-		}
-	}
-
-	static var audioVisualizationDefaultGradientStartColor: UIColor {
-		return UIColor(red: 61.0 / 255.0, green: 20.0 / 255.0, blue: 117.0 / 255.0, alpha: 1.0)
-	}
-	static var audioVisualizationDefaultGradientEndColor: UIColor {
-		return UIColor(red: 166.0 / 255.0, green: 150.0 / 255.0, blue: 225.0 / 255.0, alpha: 1.0)
-	}
-	
-	@IBInspectable public var gradientStartColor: UIColor = AudioVisualizationView.audioVisualizationDefaultGradientStartColor {
-		didSet {
-			self.setNeedsDisplay()
-		}
-	}
-	@IBInspectable public var gradientEndColor: UIColor = AudioVisualizationView.audioVisualizationDefaultGradientEndColor {
-		didSet {
-			self.setNeedsDisplay()
-		}
-	}
-
-	override public func draw(_ rect: CGRect) {
-		super.draw(rect)
-
-		if let context = UIGraphicsGetCurrentContext() {
-			self.drawLevelBarsMaskAndGradient(inContext: context)
-		}
-	}
-
-	public func reset() {
-		self.meteringLevels = nil
-		self.currentGradientPercentage = nil
-		self.meteringLevelsClusteredArray.removeAll()
-		self.meteringLevelsArray.removeAll()
-		self.setNeedsDisplay()
-	}
-
-	// MARK: - Record Mode Handling
-
-	public func addMeteringLevel(_ meteringLevel: Float) {
-		guard self.audioVisualizationMode == .write else {
-			fatalError("trying to populate audio visualization view in read mode")
-		}
-
-		self.meteringLevelsArray.append(meteringLevel)
-		self.setNeedsDisplay()
-	}
-
-	public func scaleSoundDataToFitScreen() -> [Float] {
-		if self.meteringLevelsArray.isEmpty {
-			return []
-		}
-
-		self.meteringLevelsClusteredArray.removeAll()
-		var lastPosition: Int = 0
-
-		for index in 0..<self.maximumNumberBars {
-			let position: Float = Float(index) / Float(self.maximumNumberBars) * Float(self.meteringLevelsArray.count)
-			var h: Float = 0.0
-
-			if self.maximumNumberBars > self.meteringLevelsArray.count && floor(position) != position {
-				let low: Int = Int(floor(position))
-				let high: Int = Int(ceil(position))
-
-				if high < self.meteringLevelsArray.count {
-					h = self.meteringLevelsArray[low] + ((position - Float(low)) * (self.meteringLevelsArray[high] - self.meteringLevelsArray[low]))
-				} else {
-					h = self.meteringLevelsArray[low]
-				}
-			} else {
-				for nestedIndex in lastPosition...Int(position) {
-					h += self.meteringLevelsArray[nestedIndex]
-				}
-				let stepsNumber = Int(1 + position - Float(lastPosition))
-				h = h / Float(stepsNumber)
-			}
-
-			lastPosition = Int(position)
-			self.meteringLevelsClusteredArray.append(h)
-		}
-		self.setNeedsDisplay()
-		return self.meteringLevelsClusteredArray
-	}
-
-	// PRAGMA: - Play Mode Handling
-
-	public func play(for duration: TimeInterval) {
-		guard self.audioVisualizationMode == .read else {
-			fatalError("trying to read audio visualization in write mode")
-		}
-
-		guard self.meteringLevels != nil else {
-			fatalError("trying to read audio visualization of non initialized sound record")
-		}
+    public enum AudioVisualizationMode {
+        case read
+        case write
+    }
+
+    @IBInspectable public var meteringLevelBarWidth: CGFloat = 3.0 {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+    @IBInspectable public var meteringLevelBarInterItem: CGFloat = 2.0 {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+    @IBInspectable public var meteringLevelBarCornerRadius: CGFloat = 2.0 {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    public var audioVisualizationMode: AudioVisualizationMode = .read
+
+    public var audioVisualizationTimeInterval: TimeInterval = 0.05 // Time interval between each metering bar representation
+
+    // Specify a `gradientPercentage` to have the width of gradient be that percentage of the view width (starting from left)
+    // The rest of the screen will be filled by `self.gradientStartColor` to display nicely.
+    // Do not specify any `gradientPercentage` for gradient calculating fitting size automatically.
+    public var currentGradientPercentage: Float?
+
+    public var shouldDisplayBlock: Bool = false
+
+    private var meteringLevelsArray: [Float] = [] // Mutating recording array (values are percentage: 0.0 to 1.0)
+    private var meteringLevelsClusteredArray: [Float] = [] // Generated read mode array (values are percentage: 0.0 to 1.0)
+
+    private var currentMeteringLevelsArray: [Float] {
+        if !self.meteringLevelsClusteredArray.isEmpty {
+            return meteringLevelsClusteredArray
+        }
+        return meteringLevelsArray
+    }
+
+    private var playChronometer: Chronometer?
+
+    public var meteringLevels: [Float]? {
+        didSet {
+            if let meteringLevels = self.meteringLevels {
+                self.meteringLevelsClusteredArray = meteringLevels
+                self.currentGradientPercentage = 0.0
+                _ = self.scaleSoundDataToFitScreen()
+            }
+        }
+    }
+
+    static var audioVisualizationDefaultGradientStartColor: UIColor {
+        return UIColor(red: 61.0 / 255.0, green: 20.0 / 255.0, blue: 117.0 / 255.0, alpha: 1.0)
+    }
+    static var audioVisualizationDefaultGradientEndColor: UIColor {
+        return UIColor(red: 166.0 / 255.0, green: 150.0 / 255.0, blue: 225.0 / 255.0, alpha: 1.0)
+    }
+
+    @IBInspectable public var gradientStartColor: UIColor = AudioVisualizationView.audioVisualizationDefaultGradientStartColor {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+    @IBInspectable public var gradientEndColor: UIColor = AudioVisualizationView.audioVisualizationDefaultGradientEndColor {
+        didSet {
+            self.setNeedsDisplay()
+        }
+    }
+
+    override public func draw(_ rect: CGRect) {
+        super.draw(rect)
+
+        if let context = UIGraphicsGetCurrentContext() {
+            self.drawLevelBarsMaskAndGradient(inContext: context)
+        }
+    }
+
+    public func reset() {
+        self.meteringLevels = nil
+        self.currentGradientPercentage = nil
+        self.meteringLevelsClusteredArray.removeAll()
+        self.meteringLevelsArray.removeAll()
+        self.setNeedsDisplay()
+    }
+
+
+    // MARK: - Record Mode Handling
+
+    public func addMeteringLevel(_ meteringLevel: Float) {
+        guard self.audioVisualizationMode == .write else {
+            fatalError("trying to populate audio visualization view in read mode")
+        }
+
+        self.meteringLevelsArray.append(meteringLevel)
+        self.setNeedsDisplay()
+    }
+
+    public func scaleSoundDataToFitScreen() -> [Float] {
+        if self.meteringLevelsArray.isEmpty {
+            return []
+        }
+
+        self.meteringLevelsClusteredArray.removeAll()
+        var lastPosition: Int = 0
+
+        for index in 0..<self.maximumNumberBars {
+            let position: Float = Float(index) / Float(self.maximumNumberBars) * Float(self.meteringLevelsArray.count)
+            var h: Float = 0.0
+
+            if self.maximumNumberBars > self.meteringLevelsArray.count && floor(position) != position {
+                let low: Int = Int(floor(position))
+                let high: Int = Int(ceil(position))
+
+                if high < self.meteringLevelsArray.count {
+                    h = self.meteringLevelsArray[low] + ((position - Float(low)) * (self.meteringLevelsArray[high] - self.meteringLevelsArray[low]))
+                } else {
+                    h = self.meteringLevelsArray[low]
+                }
+            } else {
+                for nestedIndex in lastPosition...Int(position) {
+                    h += self.meteringLevelsArray[nestedIndex]
+                }
+                let stepsNumber = Int(1 + position - Float(lastPosition))
+                h = h / Float(stepsNumber)
+            }
+
+            lastPosition = Int(position)
+            self.meteringLevelsClusteredArray.append(h)
+        }
+        self.setNeedsDisplay()
+        return self.meteringLevelsClusteredArray
+    }
+
+    // PRAGMA: - Play Mode Handling
+
+    public func play(for duration: TimeInterval) {
+        guard self.audioVisualizationMode == .read else {
+            fatalError("trying to read audio visualization in write mode")
+        }
+
+        guard self.meteringLevels != nil else {
+            fatalError("trying to read audio visualization of non initialized sound record")
+        }
+
+        if let currentChronometer = self.playChronometer {
+            currentChronometer.start() // resume current
+            return
+        }
+
+        self.playChronometer = Chronometer(withTimeInterval: self.audioVisualizationTimeInterval)
+        self.playChronometer?.start(shouldFire: false)
+
+        self.playChronometer?.timerDidUpdate = { [weak self] timerDuration in
+            guard let this = self else {
+                return
+            }
+
+            if timerDuration >= duration {
+                this.stop()
+                return
+            }
+
+            this.currentGradientPercentage = Float(timerDuration) / Float(duration)
+            this.setNeedsDisplay()
+        }
+    }
+
+    public func play(from position: TimeInterval, fromTotalDuration duration: TimeInterval, shouldContinuePlaying: Bool) {
+
+        self.currentGradientPercentage = Float(position) / Float(duration)
+        self.setNeedsDisplay()
+
+        if let isPlaying = playChronometer?.isPlaying {
+            if isPlaying { pause() }
+        }
+
+        self.playChronometer?.timerCurrentValue = position
+        if let currentChronometer = self.playChronometer {
+            currentChronometer.start() // resume current
+            return
+        }
+
+        self.playChronometer = Chronometer(withTimeInterval: self.audioVisualizationTimeInterval)
+        self.playChronometer?.start(shouldFire: false)
+        if shouldContinuePlaying {
+            self.playChronometer?.timerDidUpdate = { [weak self] timerDuration in
+                guard let this = self else {
+                    return
+                }
 
-		if let currentChronometer = self.playChronometer {
-			currentChronometer.start() // resume current
-			return
-		}
+                if position >= duration {
+                    this.stop()
+                    return
+                }
 
-		self.playChronometer = Chronometer(withTimeInterval: self.audioVisualizationTimeInterval)
-		self.playChronometer?.start(shouldFire: false)
+                this.currentGradientPercentage = Float(position) / Float(duration)
+                this.setNeedsDisplay()
+            }
+        }
+    }
 
-		self.playChronometer?.timerDidUpdate = { [weak self] timerDuration in
-			guard let this = self else {
-				return
-			}
-			
-			if timerDuration >= duration {
-				this.stop()
-				return
-			}
-			
-			this.currentGradientPercentage = Float(timerDuration) / Float(duration)
-			this.setNeedsDisplay()
-		}
-	}
+    public func pause() {
+        guard let chronometer = self.playChronometer, chronometer.isPlaying else {
+            fatalError("trying to pause audio visualization view when not playing")
+        }
+        self.playChronometer?.pause()
+    }
 
-	public func pause() {
-		guard let chronometer = self.playChronometer, chronometer.isPlaying else {
-			fatalError("trying to pause audio visualization view when not playing")
-		}
-		self.playChronometer?.pause()
-	}
+    public func stop() {
+        self.playChronometer?.stop()
+        self.playChronometer = nil
 
-	public func stop() {
-		self.playChronometer?.stop()
-		self.playChronometer = nil
+        self.currentGradientPercentage = 1.0
+        self.setNeedsDisplay()
+        self.currentGradientPercentage = nil
+    }
 
-		self.currentGradientPercentage = 1.0
-		self.setNeedsDisplay()
-		self.currentGradientPercentage = nil
-	}
+    // MARK: - Mask + Gradient
 
-	// MARK: - Mask + Gradient
+    private func drawLevelBarsMaskAndGradient(inContext context: CGContext) {
+        if self.currentMeteringLevelsArray.isEmpty {
+            return
+        }
 
-	private func drawLevelBarsMaskAndGradient(inContext context: CGContext) {
-		if self.currentMeteringLevelsArray.isEmpty {
-			return
-		}
+        context.saveGState()
 
-		context.saveGState()
+        UIGraphicsBeginImageContextWithOptions(self.frame.size, false, 0.0)
 
-		UIGraphicsBeginImageContextWithOptions(self.frame.size, false, 0.0)
+        let maskContext = UIGraphicsGetCurrentContext()
+        UIColor.black.set()
 
-		let maskContext = UIGraphicsGetCurrentContext()
-		UIColor.black.set()
+        self.drawMeteringLevelBars(inContext: maskContext!)
 
-		self.drawMeteringLevelBars(inContext: maskContext!)
+        let mask = UIGraphicsGetCurrentContext()?.makeImage()
+        UIGraphicsEndImageContext()
 
-		let mask = UIGraphicsGetCurrentContext()?.makeImage()
-		UIGraphicsEndImageContext()
+        context.clip(to: self.bounds, mask: mask!)
 
-		context.clip(to: self.bounds, mask: mask!)
+        self.drawGradientOrBlock(inContext: context)
 
-		self.drawGradient(inContext: context)
+        context.restoreGState()
+    }
 
-		context.restoreGState()
-	}
+    private func drawGradientOrBlock(inContext context: CGContext) {
+        if self.currentMeteringLevelsArray.isEmpty {
+            return
+        }
 
-	private func drawGradient(inContext context: CGContext) {
-		if self.currentMeteringLevelsArray.isEmpty {
-			return
-		}
+        context.saveGState()
 
-		context.saveGState()
+        let startPoint = CGPoint(x: 0.0, y: self.centerY)
+        var endPoint = CGPoint(x: self.xLeftMostBar() + self.meteringLevelBarWidth, y: self.centerY)
 
-		let startPoint = CGPoint(x: 0.0, y: self.centerY)
-		var endPoint = CGPoint(x: self.xLeftMostBar() + self.meteringLevelBarWidth, y: self.centerY)
+        if let gradientPercentage = self.currentGradientPercentage {
+            endPoint = CGPoint(x: self.frame.size.width * CGFloat(gradientPercentage), y: self.centerY)
+        }
 
-		if let gradientPercentage = self.currentGradientPercentage {
-			endPoint = CGPoint(x: self.frame.size.width * CGFloat(gradientPercentage), y: self.centerY)
-		}
+        let colorSpace = CGColorSpaceCreateDeviceRGB()
+        let colorLocations: [CGFloat] = [0.0, 1.0]
+        let colors = [shouldDisplayBlock ? self.gradientEndColor.cgColor : self.gradientStartColor.cgColor, self.gradientEndColor.cgColor]
 
-		let colorSpace = CGColorSpaceCreateDeviceRGB()
-		let colorLocations: [CGFloat] = [0.0, 1.0]
-		let colors = [self.gradientStartColor.cgColor, self.gradientEndColor.cgColor]
+        let gradient = CGGradient(colorsSpace: colorSpace, colors: colors as CFArray, locations: colorLocations)
 
-		let gradient = CGGradient(colorsSpace: colorSpace, colors: colors as CFArray, locations: colorLocations)
+        context.drawLinearGradient(gradient!, start: startPoint, end: endPoint, options: CGGradientDrawingOptions(rawValue: 0))
 
-		context.drawLinearGradient(gradient!, start: startPoint, end: endPoint, options: CGGradientDrawingOptions(rawValue: 0))
+        context.restoreGState()
 
-		context.restoreGState()
+        if self.currentGradientPercentage != nil {
+            self.drawPlainBackground(inContext: context, fillFromXCoordinate: endPoint.x)
+        }
+    }
 
-		if self.currentGradientPercentage != nil {
-			self.drawPlainBackground(inContext: context, fillFromXCoordinate: endPoint.x)
-		}
-	}
+    private func drawPlainBackground(inContext context: CGContext, fillFromXCoordinate xCoordinate: CGFloat) {
+        context.saveGState()
 
-	private func drawPlainBackground(inContext context: CGContext, fillFromXCoordinate xCoordinate: CGFloat) {
-		context.saveGState()
+        let squarePath = UIBezierPath()
 
-		let squarePath = UIBezierPath()
+        squarePath.move(to: CGPoint(x: xCoordinate, y: 0.0))
+        squarePath.addLine(to: CGPoint(x: self.frame.size.width, y: 0.0))
+        squarePath.addLine(to: CGPoint(x: self.frame.size.width, y: self.frame.size.height))
+        squarePath.addLine(to: CGPoint(x: xCoordinate, y: self.frame.size.height))
 
-		squarePath.move(to: CGPoint(x: xCoordinate, y: 0.0))
-		squarePath.addLine(to: CGPoint(x: self.frame.size.width, y: 0.0))
-		squarePath.addLine(to: CGPoint(x: self.frame.size.width, y: self.frame.size.height))
-		squarePath.addLine(to: CGPoint(x: xCoordinate, y: self.frame.size.height))
+        squarePath.close()
+        squarePath.addClip()
 
-		squarePath.close()
-		squarePath.addClip()
+        self.gradientStartColor.setFill()
+        squarePath.fill()
 
-		self.gradientStartColor.setFill()
-		squarePath.fill()
+        context.restoreGState()
+    }
 
-		context.restoreGState()
-	}
+    // MARK: - Bars
 
-	// MARK: - Bars
+    private func drawMeteringLevelBars(inContext context: CGContext) {
+        let offset = max(self.currentMeteringLevelsArray.count - self.maximumNumberBars, 0)
 
-	private func drawMeteringLevelBars(inContext context: CGContext) {
-		let offset = max(self.currentMeteringLevelsArray.count - self.maximumNumberBars, 0)
+        for index in offset..<self.currentMeteringLevelsArray.count {
+            self.drawBar(index - offset, meteringLevelIndex: index, isUpperBar: true, context: context)
+            self.drawBar(index - offset, meteringLevelIndex: index, isUpperBar: false, context: context)
+        }
+    }
 
-		for index in offset..<self.currentMeteringLevelsArray.count {
-			self.drawBar(index - offset, meteringLevelIndex: index, isUpperBar: true, context: context)
-			self.drawBar(index - offset, meteringLevelIndex: index, isUpperBar: false, context: context)
-		}
-	}
+    private func drawBar(_ barIndex: Int, meteringLevelIndex: Int, isUpperBar: Bool, context: CGContext) {
+        context.saveGState()
 
-	private func drawBar(_ barIndex: Int, meteringLevelIndex: Int, isUpperBar: Bool, context: CGContext) {
-		context.saveGState()
+        var barPath: UIBezierPath!
 
-		var barPath: UIBezierPath!
+        let xPointForMeteringLevel = self.xPointForMeteringLevel(barIndex)
+        let heightForMeteringLevel = self.heightForMeteringLevel(self.currentMeteringLevelsArray[meteringLevelIndex])
 
-		let xPointForMeteringLevel = self.xPointForMeteringLevel(barIndex)
-		let heightForMeteringLevel = self.heightForMeteringLevel(self.currentMeteringLevelsArray[meteringLevelIndex])
+        if isUpperBar {
+            barPath = UIBezierPath(roundedRect: CGRect(x: xPointForMeteringLevel, y: self.centerY - heightForMeteringLevel,
+                width: self.meteringLevelBarWidth, height: heightForMeteringLevel), cornerRadius: self.meteringLevelBarCornerRadius)
+        } else {
+            barPath = UIBezierPath(roundedRect: CGRect(x: xPointForMeteringLevel, y: self.centerY, width: self.meteringLevelBarWidth,
+                height: heightForMeteringLevel), cornerRadius: self.meteringLevelBarCornerRadius)
+        }
 
-		if isUpperBar {
-			barPath = UIBezierPath(roundedRect: CGRect(x: xPointForMeteringLevel, y: self.centerY - heightForMeteringLevel,
-				width: self.meteringLevelBarWidth, height: heightForMeteringLevel), cornerRadius: self.meteringLevelBarCornerRadius)
-		} else {
-			barPath = UIBezierPath(roundedRect: CGRect(x: xPointForMeteringLevel, y: self.centerY, width: self.meteringLevelBarWidth,
-				height: heightForMeteringLevel), cornerRadius: self.meteringLevelBarCornerRadius)
-		}
+        UIColor.black.set()
+        barPath.fill()
 
-		UIColor.black.set()
-		barPath.fill()
+        context.restoreGState()
+    }
 
-		context.restoreGState()
-	}
+    // MARK: - Points Helpers
 
-	// MARK: - Points Helpers
+    private var centerY: CGFloat {
+        return self.frame.size.height / 2.0
+    }
 
-	private var centerY: CGFloat {
-		return self.frame.size.height / 2.0
-	}
+    private var maximumBarHeight: CGFloat {
+        return self.frame.size.height / 2.0
+    }
 
-	private var maximumBarHeight: CGFloat {
-		return self.frame.size.height / 2.0
-	}
+    private var maximumNumberBars: Int {
+        return Int(self.frame.size.width / (self.meteringLevelBarWidth + self.meteringLevelBarInterItem))
+    }
 
-	private var maximumNumberBars: Int {
-		return Int(self.frame.size.width / (self.meteringLevelBarWidth + self.meteringLevelBarInterItem))
-	}
+    private func xLeftMostBar() -> CGFloat {
+        return self.xPointForMeteringLevel(min(self.maximumNumberBars - 1, self.currentMeteringLevelsArray.count - 1))
+    }
 
-	private func xLeftMostBar() -> CGFloat {
-		return self.xPointForMeteringLevel(min(self.maximumNumberBars - 1, self.currentMeteringLevelsArray.count - 1))
-	}
+    private func heightForMeteringLevel(_ meteringLevel: Float) -> CGFloat {
+        return CGFloat(meteringLevel) * self.maximumBarHeight
+    }
 
-	private func heightForMeteringLevel(_ meteringLevel: Float) -> CGFloat {
-		return CGFloat(meteringLevel) * self.maximumBarHeight
-	}
-
-	private func xPointForMeteringLevel(_ atIndex: Int) -> CGFloat {
-		return CGFloat(atIndex) * (self.meteringLevelBarWidth + self.meteringLevelBarInterItem)
-	}
+    private func xPointForMeteringLevel(_ atIndex: Int) -> CGFloat {
+        return CGFloat(atIndex) * (self.meteringLevelBarWidth + self.meteringLevelBarInterItem)
+    }
 }

--- a/SoundWave/Classes/Chronometer.swift
+++ b/SoundWave/Classes/Chronometer.swift
@@ -26,7 +26,9 @@ public final class Chronometer: NSObject {
 	public func start(shouldFire fire: Bool = true) {
 		self.timer = Timer(timeInterval: self.timeInterval, target: self, selector: #selector(Chronometer.timerDidTrigger), userInfo: nil, repeats: true)
 		RunLoop.main.add(self.timer!, forMode: RunLoopMode.defaultRunLoopMode)
-		self.timer?.fire()
+        if fire {
+            self.timer?.fire()
+        }
 		self.isPlaying = true
 	}
 


### PR DESCRIPTION
I used Bogdan's pull request and modified it, since it was buggy.

Changes:

- Replaced AudioVizualizationView's play(for:) method to play(from: totalDuration:) with the default from value set to 0.
- Introduced resume() method, which is supposed to be used only after pause() method.
- Introduced move(to: fromTotalDuration:) method to be able to adjust the current gradient position (can be used both when playing and paused).
Other changes:
     - Added microphone usage description into example so the app doesn't crash on the start
     - Fixed chronometer method start(shouldFire:) ignoring the shouldFire argument.