### PR TITLE
Swift 4 pod/project compatibility

### DIFF
--- a/SoundWave/Classes/Chronometer.swift
+++ b/SoundWave/Classes/Chronometer.swift
@@ -25,7 +25,7 @@ public final class Chronometer: NSObject {
 
 	public func start(shouldFire fire: Bool = true) {
 		self.timer = Timer(timeInterval: self.timeInterval, target: self, selector: #selector(Chronometer.timerDidTrigger), userInfo: nil, repeats: true)
-		RunLoop.main.add(self.timer!, forMode: RunLoopMode.defaultRunLoopMode)
+		RunLoop.main.add(self.timer!, forMode: RunLoop.Mode.default)
 		self.timer?.fire()
 		self.isPlaying = true
 	}

--- a/SoundWave/Classes/Chronometer.swift
+++ b/SoundWave/Classes/Chronometer.swift
@@ -25,7 +25,7 @@ public final class Chronometer: NSObject {
 
 	public func start(shouldFire fire: Bool = true) {
 		self.timer = Timer(timeInterval: self.timeInterval, target: self, selector: #selector(Chronometer.timerDidTrigger), userInfo: nil, repeats: true)
-		RunLoop.main.add(self.timer!, forMode: RunLoop.Mode.default)
+		RunLoop.main.add(self.timer!, forMode: .default)
 		self.timer?.fire()
 		self.isPlaying = true
 	}


### PR DESCRIPTION
I recently added this pod to one of my personal projects, when I built it I got the error that "RunLoopMode has been deprecated in favor of RunLoop.mode.Default" so I changed it, now hopefully users within swift4 can use this without having that issue. Small fix.