### PR TITLE
Add `meteringLevelBarSingleStick` design option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ self.audioVisualizationView.meteringLevelBarInterItem = 1.0
 self.audioVisualizationView.meteringLevelBarCornerRadius = 0.0
 ```
 
+You can change style of level bar to single:
+```swift
+self.audioVisualizationView.meteringLevelBarSingleStick = true
+```
+
 You can change grandient start and end color:
 
 ```swift


### PR DESCRIPTION
Hi. @bastienFalcou . 
We discussed about removing the middle lines on the level-meter bar in [issue40](https://github.com/bastienFalcou/SoundWave/issues/40).
So I create PR about this.

The contents of this PR are as follows.

First, I added design option `meteringLevelBarSingleStick`.
```
@IBInspectable public var meteringLevelBarSingleStick: Bool = false {
    didSet {
        self.setNeedsDisplay()
    }
}
```

Second, I added `LevelBarType` enum that determine shapes of level-meter bar.
```
private enum LevelBarType {
    case upper
    case lower
    case single
}
```

Last, I attach the sample gif files.

![ezgif com-resize](https://user-images.githubusercontent.com/13335632/59410484-eb8d8300-8df3-11e9-9b98-aa456abfaa7d.gif)
Original sample.

![ezgif com-resize-2](https://user-images.githubusercontent.com/13335632/59410553-1677d700-8df4-11e9-82df-6376761e7172.gif)
After `audioVisualizationView.meteringLevelBarSingleStick = true`.
